### PR TITLE
Refactor to support Crystal 1.1.1

### DIFF
--- a/src/fiberpool/version.cr
+++ b/src/fiberpool/version.cr
@@ -1,5 +1,5 @@
 class Fiber
   class Pool
-    VERSION = "0.2.1"
+    VERSION = "0.2.2"
   end
 end


### PR DESCRIPTION
First off, @akitaonrails, thank you for creating this!  It's exactly what I needed for my project.  

I upgraded to Crystal 1.1.1 and everything broke, though :( I saw also that #3 refers to the same issue.

So I dug in, and in I did a small refactor for compatibility with Crystal 1.1.1

The issue is that the Crystal team made `Channel::StrictReceiveAction` private in [#9564](https://github.com/crystal-lang/crystal/pull/9564) and, in general in other discussions, has discouraged folks from using internal Channel implementation details.  So really, we should just be using Channel#send and Channel#receive.

So I modified the code here slightly to do that.  Instead of an array of Channels (one for each worker), I'm using a single communication channel and the array stores references to the workers themselves.  

This is a first stab at a solution and I'm sure it can be improved / cleaned-up, but it works!  I'm happily chugging along again.